### PR TITLE
Wip get orders filter order

### DIFF
--- a/api/src/controllers/ordersController.js
+++ b/api/src/controllers/ordersController.js
@@ -59,7 +59,7 @@ const getOrdersByEmail = async (req, res) => {
 
     order
       ? res.status(200).json(order)
-      : res.json("Order not found or ID invalid");
+      : res.json("Order not found or email invalid");
   } catch (error) {
     res.json(error.message);
   }
@@ -81,7 +81,7 @@ const postOrder = async (req, res) => {
 
     return res.status(200).json("Order created successfully");
   } catch (error) {
-    res.status(400).json(error.message);
+    res.json(error.message);
   }
 };
 

--- a/api/src/controllers/ordersController.js
+++ b/api/src/controllers/ordersController.js
@@ -1,12 +1,61 @@
 const { Order, OrderDetail, Product } = require("../db");
 const { Op } = require("sequelize");
 
-const getOrders = async () => {};
+const getOrders = async (req, res) => {
+    const pageNumber = Number.parseInt(req.query.page);
+    const sizeNumber = Number.parseInt(req.query.size);
+    let orderBy      = req.query.orderBy;
+    let orderAs      = req.query.orderAs;
+    const filtro     = req.body;
+
+    let page  = 0;
+    let size  = 12;
+    if(!Number.isNaN(pageNumber) && pageNumber > 0) page = pageNumber;
+    if(!Number.isNaN(sizeNumber) && sizeNumber > 0 && sizeNumber < 12) size = sizeNumber;
+    if(!orderBy) orderBy="updatedAt";
+    if(!orderAs) orderAs="DESC";
+
+    try{
+        const orders = await Order.findAndCountAll({
+            where: filtro,
+            order: [[orderBy, orderAs]],
+            limit: size,
+            offset: page * size
+        });
+        console.log(orders)
+        return res.status(200).json({
+            totalPages: Math.ceil(orders.count / size), 
+            products: orders.rows
+        })
+    }catch{
+        res.status(404).json({ error: "Product not found" });
+    }
+};
 
 const getOrdersById = async (req, res) => {
   try {
     const { id } = req.params;
-    const order = await Order.findByPk(id);
+    const order = await Order.findOne({
+      where: {id},
+      include: OrderDetail
+    });
+
+    order
+      ? res.status(200).json(order)
+      : res.json("Order not found or ID invalid");
+  } catch (error) {
+    res.json(error.message);
+  }
+};
+
+const getOrdersByEmail = async (req, res) => {
+  try {
+    const { email } = req.params;
+    const order = await Order.findAll({
+      where: {
+        user_email: email
+      }
+    });
 
     order
       ? res.status(200).json(order)
@@ -32,7 +81,7 @@ const postOrder = async (req, res) => {
 
     return res.status(200).json("Order created successfully");
   } catch (error) {
-    res.json(error.message);
+    res.status(400).json(error.message);
   }
 };
 
@@ -58,7 +107,8 @@ const updateOrder = async (req, res) => {
 
 module.exports = {
   getOrders,
-  getOrdersById,
+  getOrdersByEmail,
   postOrder,
   updateOrder,
+  getOrdersById
 };

--- a/api/src/routes/orderRouter.js
+++ b/api/src/routes/orderRouter.js
@@ -7,11 +7,11 @@ const orderRouter = Router();
 
 orderRouter.get("/", login, admin, getOrders);
 
-orderRouter.get("/id/:id", /* login, admin, */ getOrdersById);
+orderRouter.get("/id/:id", login, getOrdersById);
 
 orderRouter.get("/email/:email", login, getOrdersByEmail);
 
-orderRouter.post("/", /* login, */ postOrder);
+orderRouter.post("/", login, postOrder);
 
 orderRouter.put("/:id", login, admin, updateOrder);
 

--- a/api/src/routes/orderRouter.js
+++ b/api/src/routes/orderRouter.js
@@ -1,20 +1,17 @@
 const { Router } = require("express");
-const {
-  getOrders,
-  getOrdersById,
-  postOrder,
-  updateOrder,
-} = require("../controllers/ordersController");
+const { getOrders, getOrdersByEmail, getOrdersById, postOrder, updateOrder } = require("../controllers/ordersController");
 const login = require("../middlewares/login.js");
 const admin = require("../middlewares/admin.js");
 
 const orderRouter = Router();
 
-orderRouter.get("/", getOrders);
+orderRouter.get("/", login, admin, getOrders);
 
-orderRouter.get("/:id", getOrdersById);
+orderRouter.get("/id/:id", /* login, admin, */ getOrdersById);
 
-orderRouter.post("/", postOrder);
+orderRouter.get("/email/:email", login, getOrdersByEmail);
+
+orderRouter.post("/", /* login, */ postOrder);
 
 orderRouter.put("/:id", login, admin, updateOrder);
 


### PR DESCRIPTION
Se añaden endpoints para Orders y protección de las rutas con las siguientes caracteristicas:

getOrders solo por admin a /orders  recibe por query ? orderBy=... & orderAs y por body las propiedades a filtrar; la respuesta esta contada y limitada a 12 al igual que haciamos con Products también por query ? page=....& size=.... se pueden ajustar

getOrderById /orders/id/:id  esta busqueda hace un include del detalle de la orden OrderDetail con su ID Product y cantidades

getOrderByEmail /orders/email/:email  esta busqueda esta orientada para el cliente profile para ver los detalles de sus ordenes

postOrder y updateOrder ya se encuentra realizado