### PR TITLE
Wip add cancelled order

### DIFF
--- a/api/src/controllers/ordersController.js
+++ b/api/src/controllers/ordersController.js
@@ -119,10 +119,35 @@ const updateOrder = async (req, res) => {
   }
 };
 
+const updateStatus = async (req, res) => {
+  try {
+    const { id } = req.query;
+    const updateStatus = req.body;
+
+    await Order.update(
+      { ...updateStatus },
+      {
+        where: {
+          id,
+        },
+      }
+    );
+
+    /* let orderDB = await Order.findByPk(id);
+
+    emailNotifications(orderDB.user_email, 'Information about your purchase', message.statusCancelled); */ 
+
+    res.status(200).json("Status updated successfully");
+  } catch (error) {
+    res.json(error.message);
+  }
+};
+
 module.exports = {
   getOrders,
   getOrdersByEmail,
   postOrder,
   updateOrder,
-  getOrdersById
+  getOrdersById,
+  updateStatus
 };

--- a/api/src/controllers/ordersController.js
+++ b/api/src/controllers/ordersController.js
@@ -122,10 +122,10 @@ const updateOrder = async (req, res) => {
 const updateStatus = async (req, res) => {
   try {
     const { id } = req.query;
-    const updateStatus = req.body;
+    const {status} = req.params;
 
     await Order.update(
-      { ...updateStatus },
+      { status: status },
       {
         where: {
           id,

--- a/api/src/routes/orderRouter.js
+++ b/api/src/routes/orderRouter.js
@@ -1,5 +1,5 @@
 const { Router } = require("express");
-const { getOrders, getOrdersByEmail, getOrdersById, postOrder, updateOrder } = require("../controllers/ordersController");
+const { getOrders, getOrdersByEmail, getOrdersById, postOrder, updateOrder, updateStatus } = require("../controllers/ordersController");
 const login = require("../middlewares/login.js");
 const admin = require("../middlewares/admin.js");
 
@@ -14,5 +14,7 @@ orderRouter.get("/email/:email", login, getOrdersByEmail);
 orderRouter.post("/", login, postOrder);
 
 orderRouter.put("/:id", login, admin, updateOrder);
+
+orderRouter.put('/', updateStatus);
 
 module.exports = orderRouter;

--- a/api/src/routes/orderRouter.js
+++ b/api/src/routes/orderRouter.js
@@ -15,6 +15,6 @@ orderRouter.post("/", login, postOrder);
 
 orderRouter.put("/:id", login, admin, updateOrder);
 
-orderRouter.put('/', updateStatus);
+orderRouter.put('/status/:status', updateStatus);
 
 module.exports = orderRouter;


### PR DESCRIPTION
Se agregó la ruta /order/status/:status para pasar por params el estado de "cancelled" y permita cancelar una orden tanto por parte del admin como del cliente