### PR TITLE
Add admin/client uploads images product

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -12,5 +12,5 @@ db.sync({ force: true })
 app.listen(process.env.PORT, () => {
 console.log(`Server listening at port ${process.env.PORT}`); // eslint-disable-line no-console
 //para desactivar el bot solo comentar la siguiente linea
-client.initialize();
+//client.initialize();
 });

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -12,6 +12,7 @@ const categoryRouter = require('./routes/categoryRouter.js');
 const favRouter = require("./routes/favRouter.js");
 const reviewRouter = require('./routes/reviewRouter.js');
 const statsRouter = require('./routes/statsRouter.js');
+const imageRouter = require('./routes/imageRouter.js');
 
 const app = express();
 
@@ -29,6 +30,7 @@ app.use('/category', categoryRouter);
 app.use("/favourites", favRouter);
 app.use('/review', reviewRouter);
 app.use('/stats', statsRouter);
+app.use('/image', imageRouter);
 
 app.get("/authorization", login, admin, (req, res)=>{
   res.json({message: "authorized"});

--- a/api/src/controllers/imageController.js
+++ b/api/src/controllers/imageController.js
@@ -1,0 +1,59 @@
+const { Image } = require("../db.js");
+const { uploadImage, deleteImage } = require('../utils/cloudinary.js');
+
+const getImageProductId = async (req, res)=>{
+    const { id } = req.params;
+    try {
+        const images = await Image.findAll({
+            where: {
+                ProductId: id
+            },
+            attributes: ["public_id", "image"]
+        });
+        res.json(images);
+    } catch (error) {
+        res.json(error.message);
+    }
+}
+
+const postImageProductId = async (req, res)=>{
+    const { id } = req.params
+    const { image } = req.body;
+    let imgCloud = {};
+    try {
+        if(image) {
+            let imageUploaded = await uploadImage(image);
+            imgCloud.image  = imageUploaded.secure_url;
+            imgCloud.public_id = imageUploaded.public_id.split('/')[1];
+          }
+        const newImage = await Image.create({
+            ProductId: id,
+            ...imgCloud
+        })
+        res.json(newImage);
+        
+    } catch (error) {
+        res.json(error.message);
+    }
+}
+
+const deleteImageProductId = async (req, res)=>{
+    const { id } = req.params;
+    try {
+        await Image.destroy({
+            where:{
+                public_id: id,
+            }
+        })
+        await deleteImage(id);
+        res.json("Deleted successfully");
+    } catch (error) {
+        res.json(error.message);
+    }
+}
+
+module.exports = {
+    postImageProductId,
+    deleteImageProductId,
+    getImageProductId
+}

--- a/api/src/controllers/reviewController.js
+++ b/api/src/controllers/reviewController.js
@@ -1,5 +1,5 @@
 const { Product, Review } = require("../db.js");
-const { uploadImage } = require('../utils/cloudinary.js');
+const { uploadImage, deleteImage } = require('../utils/cloudinary.js');
 
 
 var newComment = false;
@@ -48,9 +48,11 @@ const postComments = async (req, res) => {
   const { image, commentRate } = req.body;
   const { email, comment, rating, idProduct, idOrder } = commentRate;
   let img;
+  let public_id
   if(image) {
     let imageUploaded = await uploadImage(image);
     img  = imageUploaded.secure_url;
+    public_id  = imageUploaded.public_id.split('/')[1];
   }
 
   try {
@@ -61,7 +63,8 @@ const postComments = async (req, res) => {
     rating: rating,
     orderId: idOrder,
     ProductId: idProduct,
-    image: img
+    image: img,
+    public_id: public_id
    });
 
    newComment = true;
@@ -79,6 +82,7 @@ try {
  
  const review = await Review.findByPk(id);
  await Review.destroy({ where: { id } });
+ await deleteImage(review.public_id);
  
  const ratingDB = await Review.findAndCountAll({
    where: { ProductId: review.ProductId },

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -6,6 +6,7 @@ const modelOrderDetail = require('./models/OrderDetail');
 const modelFav = require('./models/Fav');
 const modelReview = require('./models/Review');
 const modelCategory = require('./models/Category');
+const modelImage = require('./models/Image');
 require('dotenv').config();
 
 const { DB_USER, DB_PASSWORD, DB_HOST, DB_NAME, DB_PORT } = process.env;
@@ -23,8 +24,9 @@ modelOrderDetail(sequelize);
 modelFav(sequelize);
 modelReview(sequelize);
 modelCategory(sequelize);
+modelImage(sequelize);
 
-const { Product, User, Order, OrderDetail, Fav, Review, Category } = sequelize.models;
+const { Product, User, Order, OrderDetail, Fav, Review, Category, Image } = sequelize.models;
 
 Order.belongsToMany(Product, { through : OrderDetail})
 Product.belongsToMany(Order, { through: OrderDetail})
@@ -38,6 +40,9 @@ Review.belongsTo(Product);
 Category.hasMany(Product);
 Product.belongsTo(Category);
 
+Product.hasMany(Image);
+Image.belongsTo(Product);
+
 module.exports = {
   Product,
   User,
@@ -46,5 +51,6 @@ module.exports = {
   Fav,
   Category,
   Review,
+  Image,
   db: sequelize,
 };

--- a/api/src/models/Image.js
+++ b/api/src/models/Image.js
@@ -1,0 +1,27 @@
+const { DataTypes } = require('sequelize');
+
+module.exports= (sequelize) => {    
+    sequelize.define(
+      "Image",
+      {
+        id: {
+          type: DataTypes.INTEGER,
+          autoIncrement: true,
+          primaryKey: true,
+        },
+        image: {
+            type: DataTypes.STRING,
+            valide: {
+                isUrl: true
+            }
+        },
+        public_id: {
+            type: DataTypes.STRING,
+            unique: true
+        }
+      },
+      {
+        timestamps: false,
+      }
+    );
+};

--- a/api/src/models/Review.js
+++ b/api/src/models/Review.js
@@ -34,6 +34,10 @@ module.exports = (sequelize) => {
         type: DataTypes.INTEGER,
         allowNull: false,
       },
+      public_id: {
+        type: DataTypes.STRING,
+        unique: true
+      }
     },
     {
       timestamps: true,

--- a/api/src/routes/imageRouter.js
+++ b/api/src/routes/imageRouter.js
@@ -1,0 +1,16 @@
+const { Router } = require('express');
+const { postImageProductId, deleteImageProductId, getImageProductId } = require('../controllers/imageController');
+const login = require("../middlewares/login.js");
+const admin = require("../middlewares/admin.js");
+const fileUpload = require('../middlewares/fileUpload.js');
+
+
+const imageRouter = Router();
+
+imageRouter.get('/:id', getImageProductId);
+
+imageRouter.post('/product/:id', login, admin, fileUpload, postImageProductId);
+
+imageRouter.delete('/:id', login, admin, deleteImageProductId);
+
+module.exports = imageRouter;

--- a/api/src/utils/cloudinary.js
+++ b/api/src/utils/cloudinary.js
@@ -17,7 +17,7 @@ const uploadImage = async (filePath)=>{
 }
 
 const deleteImage = async (publicId)=>{
-    return await cloudinary.uploader.destroy(publicId);
+    return await cloudinary.uploader.destroy(`tecnoshop/${publicId}`);
 }
 
 module.exports= {

--- a/client/src/components/Dashboard/Products/ImageProduct.jsx
+++ b/client/src/components/Dashboard/Products/ImageProduct.jsx
@@ -1,0 +1,107 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import axios from "axios";
+import { useEffect } from "react";
+import { useState } from "react";
+import { useLocation } from "react-router-dom"
+import { toast } from "react-toastify";
+import spinner from '../../spinner.gif';
+
+
+export default function ImageProduct(){
+
+    const location = useLocation();
+    const { getAccessTokenSilently } = useAuth0();
+    const id = location.state;
+    const [preview, setPreview] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [images, setImages] = useState([]);
+
+    const getImages = async()=>{
+        const result = await axios.get(`/image/${id}`);
+        setImages(result.data);
+
+    }
+
+    useEffect(()=>{
+        getImages();
+    }, [])
+  
+    const handleInputImg= (e)=>{
+        const file= e.target.files[0]
+        previewFile(file);
+    }
+
+    const previewFile=(file)=>{
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onloadend= ()=>{
+            setPreview(reader.result)
+        }
+    }
+
+    const uploadImage = async ()=>{
+        try {
+            setLoading(true);
+            const token = await getAccessTokenSilently();
+            const response = await axios.post(`/image/product/${id}`, { image: preview },
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`
+                    }
+                })
+            setLoading(false);
+            setPreview(false);
+
+            getImages();
+            if (response.status === 200) toast.success('Updated successfully');
+            
+        } catch (error) {
+            console.log(error);
+            setLoading(false);
+            toast.error('Something wrong');
+        }
+    }
+
+    const deleteImage = async (public_id)=>{
+        try {
+            const token = await getAccessTokenSilently();
+            const response = await axios.delete(`/image/${public_id}`,
+                    {
+                        headers: {
+                            Authorization: `Bearer ${token}`
+                        }
+                    })
+            if (response.status === 200) toast.success('Delete successfully');
+            getImages();
+            
+        } catch (error) {
+            console.log(error);
+            toast.error('Something wrong');
+        }
+    }
+
+    return (
+        <div className="container">
+            <h1 className="text-center py-2  text-danger">Upload product photos (ID:{id})</h1>
+            <div className="d-flex" style={{gap: "5rem"}}>
+            <div>
+
+            <input onChange={handleInputImg} type="file" name="image" accept='image/*' id="image" style={{"display":"none"}}/>
+            {loading
+            ?<div style={{width: "20rem"}}><img src={spinner} alt="loading" /></div>
+            :<img style={{width: "20rem"}} src={preview ||"https://removal.ai/wp-content/uploads/2021/02/no-img.png" } alt="photo" />
+            }
+            <br/>
+            <label for="image" className='my-2 mx-1 btn btn-secondary'>Select Photo</label>
+            <button disabled={!preview} type="submit" className="btn btn-success text-center" onClick={uploadImage} ><i className="me-2 fa-solid fa-floppy-disk"></i> Save</button>
+            </div>
+            <div>
+                {images?.length>0
+                ? images.map(img=><img onClick={()=>deleteImage(img.public_id)} className="m-1 img-thumbnail" style={{width:"10rem"}} src={img.image} alt="product"/>)
+                :<></>
+            }
+            </div>
+            </div>
+        </div>
+    )
+}

--- a/client/src/components/Dashboard/Products/ProductTableRow.jsx
+++ b/client/src/components/Dashboard/Products/ProductTableRow.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { getCategories } from '../../../redux/actions';
 import { nameCategory } from '../../../utils/nameCategory';
 
@@ -8,6 +9,7 @@ export default function ProductsTableRow({ p, deleteP, updateProduct, setShow, s
 
     const categories = useSelector(state=>state.categories);
     const dispatch = useDispatch();
+    const history = useHistory();
 
     useEffect(()=>{
         if(categories.length===0) dispatch(getCategories()); 
@@ -17,6 +19,10 @@ export default function ProductsTableRow({ p, deleteP, updateProduct, setShow, s
         setShow(true);
         setId(p.id);
 
+    }
+
+    function uploadImage(id){
+        history.push({ pathname: '/Dashboard/Products/Image', state: id })
     }
 
     return (
@@ -39,6 +45,10 @@ export default function ProductsTableRow({ p, deleteP, updateProduct, setShow, s
                 <td>
                     <div className="btn-group" role="group" aria-label="Basic example">
                         <button type="button" className="btn btn-sm btn-primary" onClick={delPro}><i className="fa-solid fa-trash"></i></button>
+                        <button type="button" className="btn btn-sm btn-link" onClick={()=> uploadImage(p.id)}><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-images" viewBox="0 0 16 16">
+  <path d="M4.502 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/>
+  <path d="M14.002 13a2 2 0 0 1-2 2h-10a2 2 0 0 1-2-2V5A2 2 0 0 1 2 3a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v8a2 2 0 0 1-1.998 2zM14 2H4a1 1 0 0 0-1 1h9.002a2 2 0 0 1 2 2v7A1 1 0 0 0 15 11V3a1 1 0 0 0-1-1zM2.002 4a1 1 0 0 0-1 1v8l2.646-2.354a.5.5 0 0 1 .63-.062l2.66 1.773 3.71-3.71a.5.5 0 0 1 .577-.094l1.777 1.947V5a1 1 0 0 0-1-1h-10z"/>
+</svg></button>
                         <button type="button" className="btn btn-sm btn-warning" onClick={() => updateProduct(
                             {
                                 id: p.id,

--- a/client/src/components/Reviews/AddComment.jsx
+++ b/client/src/components/Reviews/AddComment.jsx
@@ -91,14 +91,9 @@ export default function AddComment({products, email, idOrder}) {
             setPreview(reader.result)
         }
     }
-
-    const handleSubmitImg= (e)=>{
-        e.preventDefault();
-        if(!preview) return;
-        setLoading(true);
-    }
-
+    
     async function onSubmit() {
+      setLoading(true);
       const token = await getAccessTokenSilently();
   
       const comments = await axios.get('/review/' + commentRate.idProduct);
@@ -131,6 +126,8 @@ export default function AddComment({products, email, idOrder}) {
               progress: undefined,
               theme: "light",
               });
+              
+      setLoading(false);
     }
 
   return(
@@ -162,15 +159,16 @@ export default function AddComment({products, email, idOrder}) {
             </Form.Group>
           </Form>
           
-          {location.pathname==="/profile/myOrders" ? 
+          {loading
+          ?<img className='mx-0 my-0' style={{ maxWidth : '100px', maxHeight : '100px' }}  src={spinner} alt='Loading . . .' />
+          :location.pathname==="/profile/myOrders" ? 
                     <>
                     <p className='col-4'>Upload a photo of your product:</p>
                     <input onChange={handleInputImg} type="file" name="image" accept='image/*' id="image" style={{"display":"none"}}/>
                     <label for="image" className='m-2 btn btn-secondary col-3'>Select Photo</label>
                     <img style={{width: "10rem"}} src={preview ||"https://removal.ai/wp-content/uploads/2021/02/no-img.png" } alt="photo" />
                     </>
-            : <></>
-            }
+          :<></>}
 
           <div className="d-flex justify-content-around py-3 w-50 mx-auto">
             <Button disabled={errors.comment || errors.idProduct ? true : false} variant="danger" type="submit"  onClick={onSubmit}>Submit</Button>{' '}

--- a/client/src/layouts/Dashboard.jsx
+++ b/client/src/layouts/Dashboard.jsx
@@ -12,6 +12,7 @@ import DoughnutChart from '../components/Dashboard/Charts/DoughnutChart';
 import Categories from '../components/Dashboard/Categories/Categories';
 import FormCategory from '../components/Dashboard/Categories/FormCategory';
 import PolarAreaChart from '../components/Dashboard/Charts/PolarAreaChart';
+import ImageProduct from '../components/Dashboard/Products/ImageProduct';
 
 const Dashboard = () => {
 
@@ -35,6 +36,10 @@ const Dashboard = () => {
 
                             <Route exact strict path="/Dashboard/Products/Create">
                                 <FormCreate />
+                            </Route>
+
+                            <Route exact strict path="/Dashboard/Products/Image">
+                                <ImageProduct />
                             </Route>
 
                             <Route exact strict path="/Dashboard/Products/Update">


### PR DESCRIPTION
Se añade control al administrador para subir mas imágenes por productos, se puede acceder desde la tabla de productos y se asocian directamente al id, se pueden eliminar desde el mismo panel al hacer click sobre las nuevas, queda mejorar la UX
Se realiza la carga y la eliminación correcta tanto en modelos como en cloudinary
Se pueden acceder a las imágenes de los productos por su id con un get a /image/:id